### PR TITLE
Add an additional OpenVPN parameters, migrate to Terraform 0.13

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -3,7 +3,7 @@ data "aws_ami" "amazon_linux_2" {
 
   filter {
     name   = "name"
-    values = ["amzn2-ami-hvm*"]
+    values = [var.aws_ami_name]
   }
 
   filter {
@@ -13,12 +13,12 @@ data "aws_ami" "amazon_linux_2" {
 
   filter {
     name   = "block-device-mapping.volume-type"
-    values = ["gp2"]
+    values = [var.aws_ami_vol_type]
   }
 
   filter {
     name   = "virtualization-type"
-    values = ["hvm"]
+    values = [var.aws_ami_virt_type]
   }
 
   owners = ["amazon"]
@@ -76,7 +76,21 @@ resource "null_resource" "openvpn_bootstrap" {
       <<EOT
       sudo AUTO_INSTALL=y \
            APPROVE_IP=${aws_eip.openvpn_eip.public_ip} \
-           ENDPOINT=${aws_eip.openvpn_eip.public_dns} \
+           ENDPOINT=${var.use_public_dns ? aws_eip.openvpn_eip.public_dns : aws_eip.openvpn_eip.public_ip} \
+           PORT=${var.ovpn_port} \
+           CLIENT=${var.ovpn_client} \
+           CIPHER=${var.ovpn_cipher} \
+           TLS_SIG=${var.ovpn_tls_sig} \
+           SRV_BUFF_SIZE_MAX=${var.ovpn_srv_buff_size_max} \
+           SRV_BUFF_SIZE_DEFAULT=${var.ovpn_srv_buff_size_default} \
+           CLIENT_BUFF_SIZE=${var.ovpn_client_buff_size} \
+           DNS=${var.ovpn_dns}  \
+           IPV6_SUPPORT=n \
+           PORT_CHOICE=2 \
+           PROTOCOL_CHOICE=1 \
+           COMPRESSION_ENABLED=n \
+           PASS=1 \
+           CUSTOMIZE_ENC=n \
            ./openvpn-install.sh
       
 EOT

--- a/providers.tf
+++ b/providers.tf
@@ -1,6 +1,13 @@
-provider "aws" {
-  version = "~> 2.7"
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 2.7"
+    }
+  }
+}
 
+provider "aws" {
   region                  = var.aws_region
   shared_credentials_file = var.shared_credentials_file
   profile                 = var.profile

--- a/terraform-plan.sh
+++ b/terraform-plan.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set +x
+# set -e
+
+
+if [ "$#" -lt 1 ]; then
+    script_name=$(basename "$0")
+    echo "Usage:   ${script_name} <input-file-name>"
+    echo "Example: ${script_name} example"
+    exit -1
+fi
+
+WORKSPACE=$1
+
+# Select/Create Terraform Workspace
+terraform workspace select "${WORKSPACE}"
+IS_WORKSPACE_PRESENT=$?
+if [ "${IS_WORKSPACE_PRESENT}" -ne "0" ]
+then
+    terraform workspace new "${WORKSPACE}"
+fi
+
+
+terraform plan -var-file=settings/${WORKSPACE}.tfvars

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,21 @@ variable "instance_root_block_device_volume_size" {
   default     = 8
 }
 
+variable "aws_ami_name" {
+  description = "The AWS AMI name patter to use for instance creation"
+  default     = "mzn2-ami-hvm*"
+}
+
+variable "aws_ami_vol_type" {
+  description = "The AWS Storage type of AMI"
+  default     = "gp2"
+}
+
+variable "aws_ami_virt_type" {
+  description = "The AWS virtualization type of AMI"
+  default     = "hvm"
+}
+
 variable "ec2_username" {
   description = "The user to connect to the EC2 as"
   default     = "ec2-user"
@@ -39,6 +54,12 @@ variable "ec2_username" {
 variable "openvpn_install_script_location" {
   description = "The location of an OpenVPN installation script compatible with https://raw.githubusercontent.com/angristan/openvpn-install/master/openvpn-install.sh"
   default     = "https://raw.githubusercontent.com/dumrauf/openvpn-install/master/openvpn-install.sh"
+}
+
+variable "use_public_dns" {
+  type = bool
+  description = "Define the OpenVPN endpoint as a public dns"
+  default     = true
 }
 
 variable "ssh_public_key_file" {
@@ -53,6 +74,17 @@ variable "ssh_private_key_file" {
   default     = "settings/openvpn"
 }
 
+variable "ovpn_port" {
+  type        = number
+  description = "The OpenVPN port"
+  default     = 1194
+}
+
+variable "ovpn_client" {
+  description = "The client name"
+  default     = "client"
+}
+
 variable "ovpn_users" {
   type        = list(string)
   description = "The list of users to automatically provision with OpenVPN access"
@@ -63,3 +95,37 @@ variable "ovpn_config_directory" {
   default     = "generated/ovpn-config"
 }
 
+variable "ovpn_tls_sig" {
+  type        = number
+  description = "The OpenVPN TLS security type, 2-tls-auth, 1-tls-crypt"
+  default     = 1
+}
+
+variable "ovpn_cipher" {
+  description = "The OpenVPN cipher to use"
+  default     = "AES-256-CBC"
+}
+
+variable "ovpn_dns" {
+  type        = number
+  description = "The OpenVPN DNS to use."
+  default     = 1
+}
+
+variable "ovpn_srv_buff_size_max" {
+  type        = number
+  description = "Define the TCP/UDP socket send/receive max buffer size for the OpenVPN server"
+  default     = 8388608
+}
+
+variable "ovpn_srv_buff_size_default" {
+  type        = number
+  description = "Define the TCP/UDP socket send/receive default buffer size for the OpenVPN server"
+  default     = 262143
+}
+
+variable "ovpn_client_buff_size" {
+  type        = number
+  description = "Define the TCP/UDP socket send/receive buffer size for the OpenVPN client"
+  default     = 262143
+}

--- a/vpc.tf
+++ b/vpc.tf
@@ -54,8 +54,8 @@ resource "aws_security_group" "openvpn" {
   }
 
   ingress {
-    from_port   = 1194
-    to_port     = 1194
+    from_port   = var.ovpn_port
+    to_port     = var.ovpn_port
     protocol    = "udp"
     cidr_blocks = ["0.0.0.0/0"]
   }

--- a/workstation-external-ip.tf
+++ b/workstation-external-ip.tf
@@ -3,6 +3,6 @@ data "http" "local_ip_address" {
 }
 
 locals {
-  local_ip_address = "${chomp(data.http.local_ip_address.body)}/32"
+  local_ip_address = "${chomp(data.http.local_ip_address.response_body)}/32"
 }
 


### PR DESCRIPTION
# AWS settings ex:
aws_region = "eu-west-1"
shared_credentials_file = "/Users/.../.aws/credentials" profile = "2025"
aws_ami_name = "ubuntu/images/hvm-ssd/ubuntu-jammy*" aws_ami_vol_type = "gp2"
aws_ami_virt_type = "hvm"
ec2_username = "ubuntu"
ovpn_users = ["eu", "eu_router"]
use_public_dns = false
ovpn_port = 43194
ovpn_client = "eu"
ovpn_tls_sig = 3
ovpn_dns = 3
ovpn_cipher = "AES-256-CBC"
ovpn_srv_buff_size_max = 8388608
ovpn_srv_buff_size_default = 262143
ovpn_client_buff_size = 262143
instance_type="t2.micro"
openvpn_install_script_location="https://raw.githubusercontent.com/amoschov/openvpn-install/develop/openvpn-install.sh"